### PR TITLE
Add CLAUDE.md for AI assistant guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Content, templates, and styles are separated so that resume updates never requir
 
 ## Conventions
 
-- `<dd>` elements (in `#work`) and `<li>` elements (in `#awards`, `#volunteer`, `#certificates`) are given stable `id` attributes built from `slug`-filtered fields (e.g. `{{ group.name | slug }}--{{ r.position | slug }}-...`) to enable deep links. `<dt>` elements and the `#projects` `<dd>`s currently don't have ids — preserve and expand this pattern when adding sections.
+- `<dt>`, `<dd>`, and `<li>` elements are all given stable `id` attributes built from `slug`-filtered fields to enable deep links. Because work `name` and project `entity` values overlap heavily (e.g. `Google`, `Microsoft`), the `<dl>`-based sections namespace their `<dt>` ids with a section prefix: `work--{{ group.name | slug }}`, `projects--{{ group.name | slug }}`. Preserve this pattern — any new `<dl>` section that could share group-name values with another should prefix its `<dt>` ids.
 - Emoji section headings use the "Noto Emoji" web font loaded with a `text=` subset in `style.scss`. When adding a new emoji heading, add that emoji to the `text=` list in the `@import url(...)` at the top of `src/sass/style.scss`, or it won't render in the intended font.
 - `_headers` (Netlify) sets long-cache immutable headers on all assets and short cache on HTML; it is copied into `dist/` as a passthrough.
 - The whole body uses `text-transform: lowercase` — content in `resume.json` can be written in natural case.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Content, templates, and styles are separated so that resume updates never requir
 
 ## Conventions
 
-- `<dt>`/`<dd>` and `<li>` elements are given stable `id` attributes built from `slug`-filtered fields (e.g. `{{ group.name | slug }}--{{ r.position | slug }}-...`) to enable deep links — preserve this pattern when adding sections.
+- `<dd>` elements (in `#work`) and `<li>` elements (in `#awards`, `#volunteer`, `#certificates`) are given stable `id` attributes built from `slug`-filtered fields (e.g. `{{ group.name | slug }}--{{ r.position | slug }}-...`) to enable deep links. `<dt>` elements and the `#projects` `<dd>`s currently don't have ids — preserve and expand this pattern when adding sections.
 - Emoji section headings use the "Noto Emoji" web font loaded with a `text=` subset in `style.scss`. When adding a new emoji heading, add that emoji to the `text=` list in the `@import url(...)` at the top of `src/sass/style.scss`, or it won't render in the intended font.
 - `_headers` (Netlify) sets long-cache immutable headers on all assets and short cache on HTML; it is copied into `dist/` as a passthrough.
 - The whole body uses `text-transform: lowercase` — content in `resume.json` can be written in natural case.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+A single-page static resume site for Mark McLaughlin, built with [Eleventy](https://11ty.dev) and sourced from a [JSON Resume](https://jsonresume.org) schema document. Deployed to Netlify.
+
+## Commands
+
+Package manager is **pnpm** (v8, pinned via `packageManager`). Node version is **20** (`.node-version`).
+
+- `pnpm start` — build SASS once, then run SASS watcher and Eleventy dev server in parallel (`ELEVENTY_ENV=development`).
+- `pnpm build` — production build: compiles SASS → `dist/css`, runs Eleventy (`ELEVENTY_ENV=prod`), then minifies CSS via `lightningcss` (`postbuild` hook, enabled by `enable-pre-post-scripts=true` in `.npmrc`).
+- `pnpm run build:eleventy` / `pnpm run build:sass` — run each step individually.
+- `pnpm run webhint` — run webhint accessibility/best-practices check against the deployed site (`http://mark.mclaughlin.me.uk`), not the local build.
+
+There is no test suite and no lint script. CI (`.github/workflows/node.js.yml`) only runs `pnpm install && pnpm build`.
+
+## Architecture
+
+Content, templates, and styles are separated so that resume updates never require touching templates:
+
+- **Content** lives entirely in `src/_data/resume.json`, conforming to the JSON Resume v1.0.0 schema. Eleventy exposes it as the global `resume` variable in templates. Edit this file to update resume content.
+- **Templates** use the **Liquid** engine. `src/index.liquid` is the single page; it extends `src/_includes/base.liquid` via front-matter `layout:`. Templates iterate `resume.work`, `resume.awards`, `resume.volunteer`, `resume.certificates`, `resume.projects` and use Liquid filters (`group_by`, `sort`, `sort_natural`, `reverse`, `slug`, `escape`) plus the custom `formatDate` filter.
+- **Styles**: `src/sass/style.scss` compiled by `sass` CLI directly to `dist/css/style.css`, then minified in-place by `lightningcss` during `postbuild`. SASS is not processed through Eleventy.
+- **Eleventy config** (`eleventy.config.mjs`):
+  - `input: src`, `output: dist`.
+  - Passthrough copies: `_headers`, `src/*.png`, `favicon.ico`, `site.webmanifest`.
+  - Watch targets: `src/sass/` and `src/_data/` (so data/style edits trigger rebuilds in dev).
+  - Custom filter `formatDate` uses `dayjs`.
+  - A `prettier` transform formats every emitted `.html` file.
+- **Environment switching**: `src/_data/env.js` exposes `process.env.ELEVENTY_ENV` as `env.environment`. `base.liquid` only injects Plausible analytics and the Google site-verification meta when `env.environment == "prod"`. The `start` script sets `development`; `build` sets `prod`.
+
+## Conventions
+
+- `<dt>`/`<dd>` and `<li>` elements are given stable `id` attributes built from `slug`-filtered fields (e.g. `{{ group.name | slug }}--{{ r.position | slug }}-...`) to enable deep links — preserve this pattern when adding sections.
+- Emoji section headings use the "Noto Emoji" web font loaded with a `text=` subset in `style.scss`. When adding a new emoji heading, add that emoji to the `text=` list in the `@import url(...)` at the top of `src/sass/style.scss`, or it won't render in the intended font.
+- `_headers` (Netlify) sets long-cache immutable headers on all assets and short cache on HTML; it is copied into `dist/` as a passthrough.
+- The whole body uses `text-transform: lowercase` — content in `resume.json` can be written in natural case.
+
+## Deployment
+
+- **Netlify** builds from `netlify.toml` (`pnpm run build`, `PNPM_VERSION = "8"`), serving `dist/`.
+- GitHub Actions only verifies the build passes on push/PR; it does not deploy.

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -9,7 +9,7 @@ eleventyComputed:
   <dl>
     {% assign work_groups = resume.work | group_by: "name" %}
     {% for group in work_groups %}
-      <dt>{{ group.name }}</dt>
+      <dt id="work--{{ group.name | slug }}">{{ group.name }}</dt>
       {% assign roles = group.items | sort: "startDate" | reverse %}
       {% for r in roles %}
         <dd id="{{ group.name | slug }}--{{ r.position | slug }}-{{ r.description | slug }}">
@@ -81,10 +81,10 @@ eleventyComputed:
   <dl>
     {% assign project_groups = resume.projects | group_by: "entity" %}
     {% for group in project_groups %}
-      <dt>{{ group.name }}</dt>
+      <dt id="projects--{{ group.name | slug }}">{{ group.name }}</dt>
       {% assign projects = group.items | sort_natural: "name" %}
       {% for p in projects %}
-        <dd>
+        <dd id="projects--{{ group.name | slug }}--{{ p.name | slug }}">
           {% if p.url %}
             <a href="{{ p.url }}" rel="external noopener noreferrer" target="_blank"{%- if p.description %} title="{{ p.description | escape }}"{%- endif %}>{{ p.name }}</a>
           {% else %}


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` documenting the Eleventy + JSON Resume + SASS pipeline, pnpm/Node requirements, and dev/build commands.
- Captures non-obvious conventions: the `ELEVENTY_ENV` analytics toggle via `src/_data/env.js`, stable deep-link ids built with `slug`, and the Noto Emoji `text=` subset in `style.scss`.
- Notes that CI only runs `pnpm build` (no test/lint suite) and that `_headers` ships to Netlify via passthrough copy.

## Test plan
- [x] `pnpm build` (verified as a no-op vs. docs-only change — CI will run the same command).
