### PR TITLE
Fix schema.org microdata structure for validator compliance

### DIFF
--- a/src/_data/resume.json
+++ b/src/_data/resume.json
@@ -370,19 +370,13 @@
                 "Open Source",
                 "AI"
             ],
-            "entity": "Google",
-            "type": "SoftwareApplication",
-            "applicationCategory": "DeveloperApplication",
-            "operatingSystem": "macOS, Linux, Windows"
+            "entity": "Google"
         },
         {
             "name": "App Lifecycle Manager",
             "description": "A fully managed service for building, deploying, and operating SaaS applications at scale on Google Cloud, providing opinionated blueprints, automated tenant lifecycle management, and infrastructure-as-code principles to reduce time-to-market.",
             "url": "https://cloud.google.com/products/saas-runtime",
-            "entity": "Google",
-            "type": "SoftwareApplication",
-            "applicationCategory": "BusinessApplication",
-            "operatingSystem": "Google Cloud"
+            "entity": "Google"
         },
         {
             "name": "Visual Studio Code",
@@ -392,136 +386,92 @@
                 "Web Components",
                 "Open Source"
             ],
-            "entity": "Microsoft",
-            "type": "SoftwareApplication",
-            "applicationCategory": "DeveloperApplication"
+            "entity": "Microsoft"
         },
         {
             "name": "Visual Studio for Mac 2022",
             "url": "https://devblogs.microsoft.com/visualstudio/visual-studio-2022-for-mac-is-now-available/",
-            "entity": "Microsoft",
-            "type": "SoftwareApplication",
-            "applicationCategory": "DeveloperApplication",
-            "operatingSystem": "macOS"
+            "entity": "Microsoft"
         },
         {
             "name": "Visual Studio 2022",
             "url": "https://devblogs.microsoft.com/visualstudio/visual-studio-2022-now-available/",
-            "entity": "Microsoft",
-            "type": "SoftwareApplication",
-            "applicationCategory": "DeveloperApplication",
-            "operatingSystem": "Windows"
+            "entity": "Microsoft"
         },
         {
             "name": "Azure Boards",
             "url": "https://azure.microsoft.com/en-us/products/devops/boards/",
             "description": "Plan, track, and discuss work across teams.",
-            "entity": "Microsoft",
-            "type": "WebApplication",
-            "applicationCategory": "DeveloperApplication"
+            "entity": "Microsoft"
         },
         {
             "name": "Azure Pipelines",
             "description": "Continuously build, test, and deploy to any platform and cloud",
             "url": "https://azure.microsoft.com/en-us/products/devops/pipelines/",
-            "entity": "Microsoft",
-            "type": "WebApplication",
-            "applicationCategory": "DeveloperApplication"
+            "entity": "Microsoft"
         },
         {
             "name": "Azure Repos",
             "description": "Unlimited, cloud-hosted private Git repos for developers",
             "url": "https://azure.microsoft.com/en-us/products/devops/repos/",
-            "entity": "Microsoft",
-            "type": "WebApplication",
-            "applicationCategory": "DeveloperApplication"
+            "entity": "Microsoft"
         },
         {
             "name": "Skype for Xbox One",
             "description": "UWP application for Xbox One that allows users to make and receive Skype calls.",
             "url": "https://www.theverge.com/2017/4/13/15291216/skype-xbox-one-update-universal-windows-app",
-            "entity": "Microsoft",
-            "type": "SoftwareApplication",
-            "applicationCategory": "CommunicationApplication",
-            "operatingSystem": "Xbox One"
+            "entity": "Microsoft"
         },
         {
             "name": "Skype for HoloLens",
             "description": "Application for Windows Holographic that allows users to make and receive Skype calls.",
             "url": "https://www.theverge.com/2017/4/13/15291216/skype-xbox-one-update-universal-windows-app",
-            "entity": "Microsoft",
-            "type": "SoftwareApplication",
-            "applicationCategory": "CommunicationApplication",
-            "operatingSystem": "Windows Holographic"
+            "entity": "Microsoft"
         },
         {
             "name": "Skype for iOS",
             "description": "The first mobile video calling app to launch on iOS.",
             "url": "https://apps.apple.com/app/skype",
-            "entity": "Skype",
-            "type": "MobileApplication",
-            "applicationCategory": "CommunicationApplication",
-            "operatingSystem": "iOS"
+            "entity": "Skype"
         },
         {
             "name": "Skype for Android",
             "description": "Design and launch of Skype for Android phones and tablets.",
             "url": "https://play.google.com/store/apps/details?id=com.skype.raider",
-            "entity": "Skype",
-            "type": "MobileApplication",
-            "applicationCategory": "CommunicationApplication",
-            "operatingSystem": "Android"
+            "entity": "Skype"
         },
         {
             "name": "Skype for Samsung SMART TV",
             "url": "https://www.samsung.com/us/css/support/UN60ES8000FXZA_features.html",
-            "entity": "Skype",
-            "type": "SoftwareApplication",
-            "applicationCategory": "CommunicationApplication",
-            "operatingSystem": "Samsung Smart TV"
+            "entity": "Skype"
         },
         {
             "name": "Skype for WebOS",
             "description": "Design and launch of Skype for Palm Pre and HP TouchPad.",
             "url": "https://zatznotfunny.com/2010-11/first-look-at-skype-for-webos-on-palm-pre/",
-            "entity": "Skype",
-            "type": "MobileApplication",
-            "applicationCategory": "CommunicationApplication",
-            "operatingSystem": "webOS"
+            "entity": "Skype"
         },
         {
             "name": "Skype for Panasonic VIERA",
             "description": "Design direction for Skype on Panasonic smart TV.",
             "url": "https://markmclaughlin.info/hardware/smart-tv/panasonic/",
-            "entity": "Skype",
-            "type": "SoftwareApplication",
-            "applicationCategory": "CommunicationApplication",
-            "operatingSystem": "Panasonic VIERA"
+            "entity": "Skype"
         },
         {
             "name": "Skype for LG NetCast",
             "description": "Design direction for Skype on LG smart TV.",
             "url": "https://markmclaughlin.info/hardware/smart-tv/lg/",
-            "entity": "Skype",
-            "type": "SoftwareApplication",
-            "applicationCategory": "CommunicationApplication",
-            "operatingSystem": "LG NetCast"
+            "entity": "Skype"
         },
         {
             "name": "Skype for Series 60",
             "url": "https://www.youtube.com/watch?v=KBIPhv_vYRw",
-            "entity": "Skype",
-            "type": "MobileApplication",
-            "applicationCategory": "CommunicationApplication",
-            "operatingSystem": "Symbian S60"
+            "entity": "Skype"
         },
         {
             "name": "Skype for Nokia N800",
             "url": "https://www.engadget.com/2007-07-06-nokia-updates-n800-with-skype-and-more.html",
-            "entity": "Skype",
-            "type": "MobileApplication",
-            "applicationCategory": "CommunicationApplication",
-            "operatingSystem": "Maemo"
+            "entity": "Skype"
         },
         {
             "name": "3 Skypephone S1",
@@ -531,17 +481,12 @@
         {
             "name": "My 3",
             "url": "https://three.co.uk",
-            "entity": "Three",
-            "type": "WebApplication",
-            "applicationCategory": "BusinessApplication"
+            "entity": "Three"
         },
         {
             "name": "Skype for BlackBerry",
             "url": "https://www.cnet.com/tech/mobile/skypes-verizon-deal-spells-blackberry/",
-            "entity": "Skype",
-            "type": "MobileApplication",
-            "applicationCategory": "CommunicationApplication",
-            "operatingSystem": "BlackBerry OS"
+            "entity": "Skype"
         },
         {
             "name": "3 Skypephone S2",
@@ -562,93 +507,77 @@
             "name": "Skype for Windows Phone",
             "description": "Design and launch of Skype for Windows Phone 7.",
             "url": "https://markmclaughlin.info/mobile/windows-phone-7/",
-            "entity": "Skype",
-            "type": "MobileApplication",
-            "applicationCategory": "CommunicationApplication",
-            "operatingSystem": "Windows Phone 7"
+            "entity": "Skype"
         },
         {
             "name": "Korn",
             "description": "Design and launch of the official site supporting 1998's \"Follow The Leader\" release.",
             "url": "https://korn.com",
-            "entity": "ARTISTdirect",
-            "type": "WebSite"
+            "entity": "ARTISTdirect"
         },
         {
             "name": "Backstreet Boys",
             "description": "Design and launch of the official site supporting 1999's \"Millennium\" release.",
             "url": "https://backstreetboys.com",
-            "entity": "ARTISTdirect",
-            "type": "WebSite"
+            "entity": "ARTISTdirect"
         },
         {
             "name": "Rage Against The Machine",
             "description": "Design and launch of the official site supporting 1999's \"The Battle of Los Angeles\" release.",
             "url": "https://ratm.com",
-            "entity": "ARTISTdirect",
-            "type": "WebSite"
+            "entity": "ARTISTdirect"
         },
         {
             "name": "Indigo Girls",
             "description": "Design and launch of the official site supporting 1999's \"Come On Now Social\" release.",
             "url": "https://indigogirls.com",
-            "entity": "ARTISTdirect",
-            "type": "WebSite"
+            "entity": "ARTISTdirect"
         },
         {
             "name": "Kenny G",
             "description": "Design and launch of the official site supporting 1999's \"Faith: A Holiday Album\" release.",
             "url": "https://kennyg.com",
-            "entity": "ARTISTdirect",
-            "type": "WebSite"
+            "entity": "ARTISTdirect"
         },
         {
             "name": "Fastball",
             "url": "https://www.fastballtheband.com",
-            "entity": "ARTISTdirect",
-            "type": "WebSite"
+            "entity": "ARTISTdirect"
         },
         {
             "name": "STEPS",
             "url": "https://www.stepsofficial.co.uk",
-            "entity": "ARTISTdirect",
-            "type": "WebSite"
+            "entity": "ARTISTdirect"
         },
         {
             "name": "Mercury Rev",
             "url": "https://mercuryrev.com",
-            "entity": "V2 Records",
-            "type": "WebSite"
+            "entity": "V2 Records"
         },
         {
             "name": "Long Beach Dub Allstars",
             "url": "https://lbdamusic.com",
-            "entity": "ARTISTdirect",
-            "type": "WebSite"
+            "entity": "ARTISTdirect"
         },
         {
             "name": "Endsleigh Insurance",
             "url": "https://www.endsleigh.co.uk",
-            "entity": "Tamar",
-            "type": "WebSite"
+            "entity": "Tamar"
         },
         {
             "name": "J Sainsbury plc",
             "url": "https://www.about.sainsburys.co.uk",
-            "entity": "Tamar",
-            "type": "WebSite"
+            "entity": "Tamar"
         },
         {
             "name": "Travers Smith Braithwaite",
             "url": "https://www.traverssmith.com",
-            "entity": "Tamar",
-            "type": "WebSite"
+            "entity": "Tamar"
         },
         {
             "name": "Macfarlanes",
             "url": "https://www.macfarlanes.com/",
-            "entity": "Tamar",
-            "type": "WebSite"
+            "entity": "Tamar"
         }
     ],
     "references": [

--- a/src/_data/resume.json
+++ b/src/_data/resume.json
@@ -370,13 +370,19 @@
                 "Open Source",
                 "AI"
             ],
-            "entity": "Google"
+            "entity": "Google",
+            "type": "SoftwareApplication",
+            "applicationCategory": "DeveloperApplication",
+            "operatingSystem": "macOS, Linux, Windows"
         },
         {
             "name": "App Lifecycle Manager",
             "description": "A fully managed service for building, deploying, and operating SaaS applications at scale on Google Cloud, providing opinionated blueprints, automated tenant lifecycle management, and infrastructure-as-code principles to reduce time-to-market.",
             "url": "https://cloud.google.com/products/saas-runtime",
-            "entity": "Google"
+            "entity": "Google",
+            "type": "SoftwareApplication",
+            "applicationCategory": "BusinessApplication",
+            "operatingSystem": "Google Cloud"
         },
         {
             "name": "Visual Studio Code",
@@ -386,92 +392,136 @@
                 "Web Components",
                 "Open Source"
             ],
-            "entity": "Microsoft"
+            "entity": "Microsoft",
+            "type": "SoftwareApplication",
+            "applicationCategory": "DeveloperApplication"
         },
         {
             "name": "Visual Studio for Mac 2022",
             "url": "https://devblogs.microsoft.com/visualstudio/visual-studio-2022-for-mac-is-now-available/",
-            "entity": "Microsoft"
+            "entity": "Microsoft",
+            "type": "SoftwareApplication",
+            "applicationCategory": "DeveloperApplication",
+            "operatingSystem": "macOS"
         },
         {
             "name": "Visual Studio 2022",
             "url": "https://devblogs.microsoft.com/visualstudio/visual-studio-2022-now-available/",
-            "entity": "Microsoft"
+            "entity": "Microsoft",
+            "type": "SoftwareApplication",
+            "applicationCategory": "DeveloperApplication",
+            "operatingSystem": "Windows"
         },
         {
             "name": "Azure Boards",
             "url": "https://azure.microsoft.com/en-us/products/devops/boards/",
             "description": "Plan, track, and discuss work across teams.",
-            "entity": "Microsoft"
+            "entity": "Microsoft",
+            "type": "WebApplication",
+            "applicationCategory": "DeveloperApplication"
         },
         {
             "name": "Azure Pipelines",
             "description": "Continuously build, test, and deploy to any platform and cloud",
             "url": "https://azure.microsoft.com/en-us/products/devops/pipelines/",
-            "entity": "Microsoft"
+            "entity": "Microsoft",
+            "type": "WebApplication",
+            "applicationCategory": "DeveloperApplication"
         },
         {
             "name": "Azure Repos",
             "description": "Unlimited, cloud-hosted private Git repos for developers",
             "url": "https://azure.microsoft.com/en-us/products/devops/repos/",
-            "entity": "Microsoft"
+            "entity": "Microsoft",
+            "type": "WebApplication",
+            "applicationCategory": "DeveloperApplication"
         },
         {
             "name": "Skype for Xbox One",
             "description": "UWP application for Xbox One that allows users to make and receive Skype calls.",
             "url": "https://www.theverge.com/2017/4/13/15291216/skype-xbox-one-update-universal-windows-app",
-            "entity": "Microsoft"
+            "entity": "Microsoft",
+            "type": "SoftwareApplication",
+            "applicationCategory": "CommunicationApplication",
+            "operatingSystem": "Xbox One"
         },
         {
             "name": "Skype for HoloLens",
             "description": "Application for Windows Holographic that allows users to make and receive Skype calls.",
             "url": "https://www.theverge.com/2017/4/13/15291216/skype-xbox-one-update-universal-windows-app",
-            "entity": "Microsoft"
+            "entity": "Microsoft",
+            "type": "SoftwareApplication",
+            "applicationCategory": "CommunicationApplication",
+            "operatingSystem": "Windows Holographic"
         },
         {
             "name": "Skype for iOS",
             "description": "The first mobile video calling app to launch on iOS.",
             "url": "https://apps.apple.com/app/skype",
-            "entity": "Skype"
+            "entity": "Skype",
+            "type": "MobileApplication",
+            "applicationCategory": "CommunicationApplication",
+            "operatingSystem": "iOS"
         },
         {
             "name": "Skype for Android",
             "description": "Design and launch of Skype for Android phones and tablets.",
             "url": "https://play.google.com/store/apps/details?id=com.skype.raider",
-            "entity": "Skype"
+            "entity": "Skype",
+            "type": "MobileApplication",
+            "applicationCategory": "CommunicationApplication",
+            "operatingSystem": "Android"
         },
         {
             "name": "Skype for Samsung SMART TV",
             "url": "https://www.samsung.com/us/css/support/UN60ES8000FXZA_features.html",
-            "entity": "Skype"
+            "entity": "Skype",
+            "type": "SoftwareApplication",
+            "applicationCategory": "CommunicationApplication",
+            "operatingSystem": "Samsung Smart TV"
         },
         {
             "name": "Skype for WebOS",
             "description": "Design and launch of Skype for Palm Pre and HP TouchPad.",
             "url": "https://zatznotfunny.com/2010-11/first-look-at-skype-for-webos-on-palm-pre/",
-            "entity": "Skype"
+            "entity": "Skype",
+            "type": "MobileApplication",
+            "applicationCategory": "CommunicationApplication",
+            "operatingSystem": "webOS"
         },
         {
             "name": "Skype for Panasonic VIERA",
             "description": "Design direction for Skype on Panasonic smart TV.",
             "url": "https://markmclaughlin.info/hardware/smart-tv/panasonic/",
-            "entity": "Skype"
+            "entity": "Skype",
+            "type": "SoftwareApplication",
+            "applicationCategory": "CommunicationApplication",
+            "operatingSystem": "Panasonic VIERA"
         },
         {
             "name": "Skype for LG NetCast",
             "description": "Design direction for Skype on LG smart TV.",
             "url": "https://markmclaughlin.info/hardware/smart-tv/lg/",
-            "entity": "Skype"
+            "entity": "Skype",
+            "type": "SoftwareApplication",
+            "applicationCategory": "CommunicationApplication",
+            "operatingSystem": "LG NetCast"
         },
         {
             "name": "Skype for Series 60",
             "url": "https://www.youtube.com/watch?v=KBIPhv_vYRw",
-            "entity": "Skype"
+            "entity": "Skype",
+            "type": "MobileApplication",
+            "applicationCategory": "CommunicationApplication",
+            "operatingSystem": "Symbian S60"
         },
         {
             "name": "Skype for Nokia N800",
             "url": "https://www.engadget.com/2007-07-06-nokia-updates-n800-with-skype-and-more.html",
-            "entity": "Skype"
+            "entity": "Skype",
+            "type": "MobileApplication",
+            "applicationCategory": "CommunicationApplication",
+            "operatingSystem": "Maemo"
         },
         {
             "name": "3 Skypephone S1",
@@ -481,12 +531,17 @@
         {
             "name": "My 3",
             "url": "https://three.co.uk",
-            "entity": "Three"
+            "entity": "Three",
+            "type": "WebApplication",
+            "applicationCategory": "BusinessApplication"
         },
         {
             "name": "Skype for BlackBerry",
             "url": "https://www.cnet.com/tech/mobile/skypes-verizon-deal-spells-blackberry/",
-            "entity": "Skype"
+            "entity": "Skype",
+            "type": "MobileApplication",
+            "applicationCategory": "CommunicationApplication",
+            "operatingSystem": "BlackBerry OS"
         },
         {
             "name": "3 Skypephone S2",
@@ -507,77 +562,93 @@
             "name": "Skype for Windows Phone",
             "description": "Design and launch of Skype for Windows Phone 7.",
             "url": "https://markmclaughlin.info/mobile/windows-phone-7/",
-            "entity": "Skype"
+            "entity": "Skype",
+            "type": "MobileApplication",
+            "applicationCategory": "CommunicationApplication",
+            "operatingSystem": "Windows Phone 7"
         },
         {
             "name": "Korn",
             "description": "Design and launch of the official site supporting 1998's \"Follow The Leader\" release.",
             "url": "https://korn.com",
-            "entity": "ARTISTdirect"
+            "entity": "ARTISTdirect",
+            "type": "WebSite"
         },
         {
             "name": "Backstreet Boys",
             "description": "Design and launch of the official site supporting 1999's \"Millennium\" release.",
             "url": "https://backstreetboys.com",
-            "entity": "ARTISTdirect"
+            "entity": "ARTISTdirect",
+            "type": "WebSite"
         },
         {
             "name": "Rage Against The Machine",
             "description": "Design and launch of the official site supporting 1999's \"The Battle of Los Angeles\" release.",
             "url": "https://ratm.com",
-            "entity": "ARTISTdirect"
+            "entity": "ARTISTdirect",
+            "type": "WebSite"
         },
         {
             "name": "Indigo Girls",
             "description": "Design and launch of the official site supporting 1999's \"Come On Now Social\" release.",
             "url": "https://indigogirls.com",
-            "entity": "ARTISTdirect"
+            "entity": "ARTISTdirect",
+            "type": "WebSite"
         },
         {
             "name": "Kenny G",
             "description": "Design and launch of the official site supporting 1999's \"Faith: A Holiday Album\" release.",
             "url": "https://kennyg.com",
-            "entity": "ARTISTdirect"
+            "entity": "ARTISTdirect",
+            "type": "WebSite"
         },
         {
             "name": "Fastball",
             "url": "https://www.fastballtheband.com",
-            "entity": "ARTISTdirect"
+            "entity": "ARTISTdirect",
+            "type": "WebSite"
         },
         {
             "name": "STEPS",
             "url": "https://www.stepsofficial.co.uk",
-            "entity": "ARTISTdirect"
+            "entity": "ARTISTdirect",
+            "type": "WebSite"
         },
         {
             "name": "Mercury Rev",
             "url": "https://mercuryrev.com",
-            "entity": "V2 Records"
+            "entity": "V2 Records",
+            "type": "WebSite"
         },
         {
             "name": "Long Beach Dub Allstars",
             "url": "https://lbdamusic.com",
-            "entity": "ARTISTdirect"
+            "entity": "ARTISTdirect",
+            "type": "WebSite"
         },
         {
             "name": "Endsleigh Insurance",
             "url": "https://www.endsleigh.co.uk",
-            "entity": "Tamar"
+            "entity": "Tamar",
+            "type": "WebSite"
         },
         {
             "name": "J Sainsbury plc",
             "url": "https://www.about.sainsburys.co.uk",
-            "entity": "Tamar"
+            "entity": "Tamar",
+            "type": "WebSite"
         },
         {
             "name": "Travers Smith Braithwaite",
             "url": "https://www.traverssmith.com",
-            "entity": "Tamar"
+            "entity": "Tamar",
+            "type": "WebSite"
         },
         {
             "name": "Macfarlanes",
             "url": "https://www.macfarlanes.com/",
-            "entity": "Tamar"
+            "entity": "Tamar",
+            "type": "WebSite"
         }
     ],
     "references": [

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,7 +18,6 @@ const currentYear = new Date().getFullYear();
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="author" content={resume.basics.name} />
     <meta name="description" content={resume.basics.summary} />
-    <meta itemprop="name" content={resume.basics.name} />
     <meta itemprop="email" content={resume.basics.email} />
     <meta itemprop="url" content={resume.basics.url} />
     <meta itemprop="jobTitle" content={resume.basics.label} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -221,7 +221,7 @@ const projectGroups = groupBy(resume.projects, "entity");
               <dd
                 id={`projects--${slug(group.name)}--${slug(p.name)}`}
                 itemscope
-                itemtype={`https://schema.org/${p.type ?? "CreativeWork"}`}
+                itemtype="https://schema.org/CreativeWork"
               >
                 {p.url ? (
                   <a
@@ -238,18 +238,6 @@ const projectGroups = groupBy(resume.projects, "entity");
                 )}
                 {p.description && (
                   <meta itemprop="description" content={p.description} />
-                )}
-                {p.applicationCategory && (
-                  <meta
-                    itemprop="applicationCategory"
-                    content={p.applicationCategory}
-                  />
-                )}
-                {p.operatingSystem && (
-                  <meta
-                    itemprop="operatingSystem"
-                    content={p.operatingSystem}
-                  />
                 )}
                 <span
                   itemprop="creator"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,22 +20,15 @@ const projectGroups = groupBy(resume.projects, "entity");
       {
         workGroups.map((group) => (
           <>
-            <dt
-              id={`work--${slug(group.name)}`}
-              itemscope
-              itemtype="https://schema.org/Organization"
-              itemprop="worksFor"
-            >
-              <span itemprop="name">{group.name}</span>
-            </dt>
+            <dt id={`work--${slug(group.name)}`}>{group.name}</dt>
             {[...group.items]
               .sort((a, b) => b.startDate.localeCompare(a.startDate))
               .map((r) => (
                 <dd
                   id={`${slug(group.name)}--${slug(r.position)}-${slug(r.description)}`}
+                  itemprop="worksFor"
                   itemscope
                   itemtype="https://schema.org/EmployeeRole"
-                  itemprop="worksFor"
                 >
                   <meta
                     itemprop="startDate"
@@ -47,26 +40,42 @@ const projectGroups = groupBy(resume.projects, "entity");
                       content={formatDate(r.endDate, "YYYY-MM-DD")}
                     />
                   )}
+                  {r.summary && (
+                    <meta itemprop="description" content={r.summary.trim()} />
+                  )}
                   <time datetime={formatDate(r.startDate, "YYYY-MM-DD")}>
                     {formatDate(r.startDate, "YYYY")}
                   </time>
                   <span>
                     <span itemprop="roleName">{r.position}</span>
-                    {r.url ? (
-                      <>
-                        <a
-                          href={r.url}
-                          rel="external noopener noreferrer"
-                          target="_blank"
-                          itemprop="url"
-                        >
-                          {r.description}
-                        </a>
-                        <meta itemprop="description" content={r.description} />
-                      </>
-                    ) : (
-                      <span itemprop="description">{r.description}</span>
-                    )}
+                    <span
+                      itemprop="worksFor"
+                      itemscope
+                      itemtype="https://schema.org/Organization"
+                    >
+                      <meta itemprop="name" content={group.name} />
+                      {r.location && (
+                        <meta itemprop="location" content={r.location} />
+                      )}
+                      <span
+                        itemprop="department"
+                        itemscope
+                        itemtype="https://schema.org/Organization"
+                      >
+                        {r.url ? (
+                          <a
+                            href={r.url}
+                            rel="external noopener noreferrer"
+                            target="_blank"
+                            itemprop="url"
+                          >
+                            <span itemprop="name">{r.description}</span>
+                          </a>
+                        ) : (
+                          <span itemprop="name">{r.description}</span>
+                        )}
+                      </span>
+                    </span>
                   </span>
                 </dd>
               ))}
@@ -83,22 +92,17 @@ const projectGroups = groupBy(resume.projects, "entity");
         awards.map((a) => (
           <li
             id={`${slug(a.title)}-${slug(a.awarder)}-${formatDate(a.date, "YYYY")}`}
-            itemscope
-            itemtype="https://schema.org/Thing"
-            itemprop="award"
           >
-            <time
-              datetime={formatDate(a.date, "YYYY-MM-DD")}
-            >
+            <meta
+              itemprop="award"
+              content={`${a.title}, ${a.awarder} (${formatDate(a.date, "YYYY")})${a.summary ? ` — ${a.summary}` : ""}`}
+            />
+            <time datetime={formatDate(a.date, "YYYY-MM-DD")}>
               {formatDate(a.date, "YYYY")}
             </time>
             <span>
-              <span>{a.awarder}</span> //{" "}
-              <span itemprop="name">{a.title}</span>
+              <span>{a.awarder}</span> // <span>{a.title}</span>
             </span>
-            {a.summary && (
-              <meta itemprop="description" content={a.summary} />
-            )}
           </li>
         ))
       }
@@ -110,20 +114,45 @@ const projectGroups = groupBy(resume.projects, "entity");
     <ul>
       {
         resume.volunteer.map((v) => (
-          <li id={`${slug(v.organization)}--${slug(v.position)}`}>
+          <li
+            id={`${slug(v.organization)}--${slug(v.position)}`}
+            itemprop="affiliation"
+            itemscope
+            itemtype="https://schema.org/Role"
+          >
+            <meta
+              itemprop="startDate"
+              content={formatDate(v.startDate, "YYYY-MM-DD")}
+            />
+            {v.endDate && (
+              <meta
+                itemprop="endDate"
+                content={formatDate(v.endDate, "YYYY-MM-DD")}
+              />
+            )}
+            {v.summary && (
+              <meta itemprop="description" content={v.summary.trim()} />
+            )}
             <time datetime={formatDate(v.startDate, "YYYY-MM-DD")}>
               {formatDate(v.startDate, "YYYY")}
             </time>
             <span>
-              {v.position} at{" "}
-              <a
-                href={v.url}
-                rel="external noopener noreferrer"
-                target="_blank"
-                title={v.summary}
+              <span itemprop="roleName">{v.position}</span> at{" "}
+              <span
+                itemprop="affiliation"
+                itemscope
+                itemtype="https://schema.org/Organization"
               >
-                {v.organization}
-              </a>
+                <a
+                  href={v.url}
+                  rel="external noopener noreferrer"
+                  target="_blank"
+                  title={v.summary}
+                  itemprop="url"
+                >
+                  <span itemprop="name">{v.organization}</span>
+                </a>
+              </span>
             </span>
           </li>
         ))
@@ -138,16 +167,34 @@ const projectGroups = groupBy(resume.projects, "entity");
         certificates.map((c) => (
           <li
             id={`${slug(c.name)}-${slug(c.issuer)}-${formatDate(c.date, "YYYY")}`}
+            itemprop="hasCredential"
             itemscope
             itemtype="https://schema.org/EducationalOccupationalCredential"
-            itemprop="hasCredential"
           >
+            <meta itemprop="credentialCategory" content="certification" />
+            <meta
+              itemprop="dateCreated"
+              content={formatDate(c.date, "YYYY-MM-DD")}
+            />
             <time datetime={formatDate(c.date, "YYYY-MM-DD")}>
               {formatDate(c.date, "YYYY")}
             </time>
             <span>
-              [<span itemprop="recognizedBy">{c.issuer}</span>]{" "}
-              <a href={c.url} rel="external noopener noreferrer" target="_blank" itemprop="url">
+              [
+              <span
+                itemprop="recognizedBy"
+                itemscope
+                itemtype="https://schema.org/Organization"
+              >
+                <span itemprop="name">{c.issuer}</span>
+              </span>
+              ]{" "}
+              <a
+                href={c.url}
+                rel="external noopener noreferrer"
+                target="_blank"
+                itemprop="url"
+              >
                 <span itemprop="name">{c.name}</span>
               </a>
             </span>
@@ -163,38 +210,44 @@ const projectGroups = groupBy(resume.projects, "entity");
       {
         projectGroups.map((group) => (
           <>
-            <dt
-              id={`projects--${slug(group.name)}`}
-              itemscope
-              itemtype="https://schema.org/Organization"
-            >
-              <span itemprop="name">{group.name}</span>
-            </dt>
+            <dt id={`projects--${slug(group.name)}`}>{group.name}</dt>
             {sortNatural(group.items, "name").map((p) => (
               <dd
                 id={`projects--${slug(group.name)}--${slug(p.name)}`}
                 itemscope
                 itemtype="https://schema.org/CreativeWork"
               >
-                <span itemprop="name">
-                  {p.url ? (
-                    <a
-                      href={p.url}
-                      rel="external noopener noreferrer"
-                      target="_blank"
-                      title={p.description}
-                      itemprop="url"
-                    >
-                      {p.name}
-                    </a>
-                  ) : (
-                    p.name
-                  )}
-                </span>
+                {p.url ? (
+                  <a
+                    href={p.url}
+                    rel="external noopener noreferrer"
+                    target="_blank"
+                    title={p.description}
+                    itemprop="url"
+                  >
+                    <span itemprop="name">{p.name}</span>
+                  </a>
+                ) : (
+                  <span itemprop="name">{p.name}</span>
+                )}
                 {p.description && (
                   <meta itemprop="description" content={p.description} />
                 )}
-                <meta itemprop="creator" content={resume.basics.name} />
+                <span
+                  itemprop="creator"
+                  itemscope
+                  itemtype="https://schema.org/Person"
+                >
+                  <meta itemprop="name" content={resume.basics.name} />
+                  <meta itemprop="url" content={resume.basics.url} />
+                </span>
+                <span
+                  itemprop="publisher"
+                  itemscope
+                  itemtype="https://schema.org/Organization"
+                >
+                  <meta itemprop="name" content={group.name} />
+                </span>
                 {p.keywords &&
                   p.keywords.map((keyword) => (
                     <meta itemprop="keywords" content={keyword} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -215,7 +215,7 @@ const projectGroups = groupBy(resume.projects, "entity");
               <dd
                 id={`projects--${slug(group.name)}--${slug(p.name)}`}
                 itemscope
-                itemtype="https://schema.org/CreativeWork"
+                itemtype={`https://schema.org/${p.type ?? "CreativeWork"}`}
               >
                 {p.url ? (
                   <a
@@ -232,6 +232,18 @@ const projectGroups = groupBy(resume.projects, "entity");
                 )}
                 {p.description && (
                   <meta itemprop="description" content={p.description} />
+                )}
+                {p.applicationCategory && (
+                  <meta
+                    itemprop="applicationCategory"
+                    content={p.applicationCategory}
+                  />
+                )}
+                {p.operatingSystem && (
+                  <meta
+                    itemprop="operatingSystem"
+                    content={p.operatingSystem}
+                  />
                 )}
                 <span
                   itemprop="creator"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -55,7 +55,13 @@ const projectGroups = groupBy(resume.projects, "entity");
                     >
                       <meta itemprop="name" content={group.name} />
                       {r.location && (
-                        <meta itemprop="location" content={r.location} />
+                        <span
+                          itemprop="location"
+                          itemscope
+                          itemtype="https://schema.org/Place"
+                        >
+                          <meta itemprop="name" content={r.location} />
+                        </span>
                       )}
                       <span
                         itemprop="department"
@@ -118,7 +124,7 @@ const projectGroups = groupBy(resume.projects, "entity");
             id={`${slug(v.organization)}--${slug(v.position)}`}
             itemprop="affiliation"
             itemscope
-            itemtype="https://schema.org/Role"
+            itemtype="https://schema.org/OrganizationRole"
           >
             <meta
               itemprop="startDate"


### PR DESCRIPTION
## Summary

The previous microdata pass emitted structures that don't validate cleanly against schema.org expectations. This PR restructures all annotations to the canonical patterns so validator.schema.org and Google's Rich Results Test accept them without warnings.

### Fixes

- **Work** — `Person → worksFor → EmployeeRole → worksFor → Organization` (canonical Role pattern). Previously the `<dt>` Organization and `<dd>` EmployeeRole were sibling `worksFor` values on Person, leaving roles unlinked from employers. The employer URL moves onto a nested `department` Organization, since `resume.json`'s `url` field actually points at the team/product rather than the parent company. Adds `location` and `summary` (as `description`) which were previously dropped.
- **Volunteer** — adds `Person → affiliation → Role → affiliation → Organization` (was unannotated).
- **Certificates** — `recognizedBy` now wraps the issuer as a nested Organization node (it expects an Organization, not a text span). Adds `credentialCategory` and `dateCreated`.
- **Projects** — `creator` is a nested Person node with `name`/`url` instead of a bare text meta (creator expects Person/Organization). Adds `publisher` as a nested Organization.
- **Awards** — `Person.award` is text-only per spec; emits a single `<meta itemprop="award">` per award and drops the non-compliant `Thing` wrapper.
- **Layout** — drops the duplicate `<meta itemprop="name">` in `<head>` so the Person's name comes from the visible `<h1>` only (was producing duplicate values).

No visual or CSS changes — selectors don't depend on microdata attributes.

## Test plan

- [x] `pnpm build` completes clean
- [x] `pnpm check` passes (0 errors, 0 warnings)
- [x] Spot-checked generated `dist/index.html` for every section type
- [ ] Paste `https://mark.mclaughlin.me.uk` into [validator.schema.org](https://validator.schema.org) after deploy — no errors/warnings expected on Person, EmployeeRole, Organization, Role, EducationalOccupationalCredential, or CreativeWork nodes
- [ ] Paste the same URL into Google's [Rich Results Test](https://search.google.com/test/rich-results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)