### PR TITLE
Add publications, location, and meta to JSON Resume schema

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "start",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["run", "start"],
+      "port": 4321
+    },
+    {
+      "name": "watch:eleventy",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["run", "watch:eleventy"],
+      "port": 8080
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # Edit at https://www.toptal.com/developers/gitignore?templates=macos,node
 
 hint-report/
+.claude/settings.local.json
 
 ### macOS ###
 # General

--- a/src/_data/resume.json
+++ b/src/_data/resume.json
@@ -1,10 +1,19 @@
 {
     "$schema": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json",
+    "meta": {
+        "canonical": "https://mark.mclaughlin.me.uk",
+        "version": "1.0.0",
+        "lastModified": "2026-04-19"
+    },
     "basics": {
         "name": "Mark McLaughlin",
         "label": "UX Design Manager at Google",
         "email": "mark@mclaughlin.me.uk",
         "url": "https://mark.mclaughlin.me.uk",
+        "location": {
+            "city": "Kirkland",
+            "postalCode": "98034"
+        },
         "summary": "Design leader with almost 30 years background creating end-to-end experiences for web, cloud, terminal, mobile, desktop and consumer electronics platforms.",
         "profiles": [
             {
@@ -578,6 +587,15 @@
             "name": "Macfarlanes",
             "url": "https://www.macfarlanes.com/",
             "entity": "Tamar"
+        }
+    ],
+    "publications": [
+        {
+            "name": "The Icon Handbook",
+            "publisher": "Five Simple Steps",
+            "releaseDate": "2011-12-01",
+            "url": "https://www.fivesimplesteps.com/products/the-icon-handbook",
+            "summary": "Quoted on pages 47–49 in Jon Hicks' definitive guide to icon design. ISBN: 978-1-907828-04-1."
         }
     ],
     "references": [

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -50,7 +50,7 @@ const currentYear = new Date().getFullYear();
     <header>
       <h1 itemprop="name">{resume.basics.name}</h1>
       <p id="summary" itemprop="description">{resume.basics.summary.trim()}</p>
-      {resume.basics.location && (
+      {(resume.basics.location?.city || resume.basics.location?.postalCode || resume.basics.location?.countryCode || resume.basics.location?.region) && (
         <span itemprop="homeLocation" itemscope itemtype="https://schema.org/Place" hidden>
           <span itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
             {resume.basics.location.city && <meta itemprop="addressLocality" content={resume.basics.location.city} />}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,6 +18,9 @@ const currentYear = new Date().getFullYear();
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="author" content={resume.basics.name} />
     <meta name="description" content={resume.basics.summary} />
+    {resume.meta?.canonical && <link rel="canonical" href={resume.meta.canonical} />}
+    {resume.meta?.version && <meta name="version" content={resume.meta.version} />}
+    {resume.meta?.lastModified && <meta name="last-modified" content={resume.meta.lastModified} />}
     <meta itemprop="email" content={resume.basics.email} />
     <meta itemprop="url" content={resume.basics.url} />
     <meta itemprop="jobTitle" content={resume.basics.label} />
@@ -47,6 +50,16 @@ const currentYear = new Date().getFullYear();
     <header>
       <h1 itemprop="name">{resume.basics.name}</h1>
       <p id="summary" itemprop="description">{resume.basics.summary.trim()}</p>
+      {resume.basics.location && (
+        <span itemprop="homeLocation" itemscope itemtype="https://schema.org/Place" hidden>
+          <span itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
+            {resume.basics.location.city && <meta itemprop="addressLocality" content={resume.basics.location.city} />}
+            {resume.basics.location.postalCode && <meta itemprop="postalCode" content={resume.basics.location.postalCode} />}
+            {resume.basics.location.countryCode && <meta itemprop="addressCountry" content={resume.basics.location.countryCode} />}
+            {resume.basics.location.region && <meta itemprop="addressRegion" content={resume.basics.location.region} />}
+          </span>
+        </span>
+      )}
     </header>
     <main>
       <slot />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -210,6 +210,46 @@ const projectGroups = groupBy(resume.projects, "entity");
     </ul>
   </section>
 
+  <section id="publications">
+    <h2 title="Publications">📚<span class="sr-only">Publications</span></h2>
+    <ul>
+      {
+        resume.publications.map((p) => (
+          <li
+            id={`${slug(p.name)}-${slug(p.publisher)}-${formatDate(p.releaseDate, "YYYY")}`}
+            itemscope
+            itemtype="https://schema.org/Book"
+          >
+            <meta itemprop="datePublished" content={formatDate(p.releaseDate, "YYYY-MM-DD")} />
+            {p.summary && <meta itemprop="description" content={p.summary} />}
+            <time datetime={formatDate(p.releaseDate, "YYYY-MM-DD")}>
+              {formatDate(p.releaseDate, "YYYY")}
+            </time>
+            <span>
+              [
+              <span
+                itemprop="publisher"
+                itemscope
+                itemtype="https://schema.org/Organization"
+              >
+                <span itemprop="name">{p.publisher}</span>
+              </span>
+              ]{" "}
+              <a
+                href={p.url}
+                rel="external noopener noreferrer"
+                target="_blank"
+                itemprop="url"
+              >
+                <span itemprop="name">{p.name}</span>
+              </a>
+            </span>
+          </li>
+        ))
+      }
+    </ul>
+  </section>
+
   <section id="projects">
     <h2 title="Projects">📁<span class="sr-only">Projects</span></h2>
     <dl>

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Noto+Emoji:wght@300..700&display=swap&text=📁💼🏢🏆🫶🛠️📄👍");
+@import url("https://fonts.googleapis.com/css2?family=Noto+Emoji:wght@300..700&display=swap&text=📁💼🏢🏆🫶🛠️📄📚👍");
 
 :root {
   @supports (color: color(display-p3 1 1 1)) {


### PR DESCRIPTION
## Summary

- **Publications section**: adds _The Icon Handbook_ (Five Simple Steps, December 2011) with `schema.org/Book` microdata; adds 📚 to the Noto Emoji subset
- **`basics.location`**: adds `city: Kirkland` and `postalCode: 98034`; wired in `Layout.astro` as hidden `schema.org/homeLocation → PostalAddress` microdata, guarded for partial fields
- **`meta` block**: adds `canonical`, `version`, and `lastModified`; mapped to `<link rel="canonical">`, `<meta name="version">`, and `<meta name="last-modified">` in `<head>`

## Notes for reviewer

- `meta.lastModified` will need a manual bump on future content changes
- The Gartner/Figma publication is still TBD — placeholder research ongoing; will be a follow-up PR if/when the title and year are confirmed
- `.claude/launch.json` port corrected from 8080 → 4321 to match Astro's default dev server (not included in this PR as it's untracked)