### PR TITLE
Add patents, missing projects, and summary update

### DIFF
--- a/src/_data/resume.json
+++ b/src/_data/resume.json
@@ -674,7 +674,7 @@
             "summary": "Shared TV viewing indicators — watch shows together across platforms."
         },
         {
-            "name": "Logging communication events",
+            "name": "Logging communication events using location information",
             "number": "US9544377B2",
             "url": "https://patents.google.com/patent/US9544377B2/en",
             "summary": "Location-aware phone call log."

--- a/src/_data/resume.json
+++ b/src/_data/resume.json
@@ -674,6 +674,12 @@
             "summary": "Shared TV viewing indicators — watch shows together across platforms."
         },
         {
+            "name": "Logging communication events",
+            "number": "US9544377B2",
+            "url": "https://patents.google.com/patent/US9544377B2/en",
+            "summary": "Location-aware phone call log."
+        },
+        {
             "name": "Switching between user devices during a VoIP call",
             "number": "GB2479180A",
             "url": "https://patents.google.com/patent/GB2479180A/en",

--- a/src/_data/resume.json
+++ b/src/_data/resume.json
@@ -14,7 +14,7 @@
             "city": "Kirkland",
             "postalCode": "98034"
         },
-        "summary": "Design leader with almost 30 years background creating end-to-end experiences for web, cloud, terminal, mobile, desktop and consumer electronics platforms.",
+        "summary": "Design leader with over 30 years background creating end-to-end experiences for web, cloud, terminal, mobile, desktop and consumer electronics platforms.",
         "profiles": [
             {
                 "network": "X",
@@ -438,6 +438,18 @@
             "entity": "Microsoft"
         },
         {
+            "name": "Windows 10",
+            "description": "Design and prototyping lead for Skype Video and Messaging integration at the launch of Windows 10.",
+            "url": "https://www.microsoft.com/en-us/windows",
+            "entity": "Microsoft"
+        },
+        {
+            "name": "Office 365",
+            "description": "Design lead for the initial integration of real-time Skype communications into the Office 365 web suite, including Outlook.com and OneDrive.",
+            "url": "https://www.microsoft.com/en-us/microsoft-365",
+            "entity": "Microsoft"
+        },
+        {
             "name": "Skype for iOS",
             "description": "The first mobile video calling app to launch on iOS.",
             "url": "https://apps.apple.com/app/skype",
@@ -508,6 +520,11 @@
             "entity": "Skype"
         },
         {
+            "name": "Intel MID",
+            "description": "Collaboration with Intel to develop VoIP calling for its Mobile Internet Device concept.",
+            "entity": "Skype"
+        },
+        {
             "name": "Philips VOIP855 ",
             "url": "https://www.usa.philips.com/c-p/VOIP8551B_26/design-collection-cordless-phone-with-answering-machine",
             "entity": "Skype"
@@ -517,6 +534,12 @@
             "description": "Design and launch of Skype for Windows Phone 7.",
             "url": "https://markmclaughlin.info/mobile/windows-phone-7/",
             "entity": "Skype"
+        },
+        {
+            "name": "Monty Python",
+            "description": "Webmaster for the Monty Python online archive of Terry Gilliam artwork and Eric Idle live shows.",
+            "url": "https://montypython.com",
+            "entity": "ARTISTdirect"
         },
         {
             "name": "Korn",
@@ -610,6 +633,50 @@
         {
             "name": "John Chang, Grönska Stadsodling",
             "reference": "Mark is the man behind the UxD for Skype for iPhone. Back when the iPhone was new to everyone in the world, he somehow immediately \"got\" the look-and-feel of the platform and managed to create a design that has withstood the test of time. He's one of that rare breed who is not only skilled on the design side but groks the technical side as well."
+        }
+    ],
+    "patents": [
+        {
+            "name": "Distributing Presence Information",
+            "number": "US8473545B2",
+            "url": "https://patents.google.com/patent/US8473545B2",
+            "summary": "Setting IM availability based on calendar data."
+        },
+        {
+            "name": "Communication system and method",
+            "number": "US8407749B2",
+            "url": "https://patents.google.com/patent/US8407749B2",
+            "summary": "Handling incoming call notifications via a TV remote control."
+        },
+        {
+            "name": "Communication system and method",
+            "number": "US8473994B2",
+            "url": "https://patents.google.com/patent/US8473994B2",
+            "summary": "Generating social avatars from live TV content."
+        },
+        {
+            "name": "Indicia of contact viewing activity",
+            "number": "US9258511B2",
+            "url": "https://patents.google.com/patent/US9258511B2",
+            "summary": "Shared TV viewing indicators — watch shows together across platforms."
+        },
+        {
+            "name": "Logging communication events",
+            "number": "US20110201313A1",
+            "url": "https://patents.google.com/patent/US20110201313A1",
+            "summary": "Location-aware phone call log."
+        },
+        {
+            "name": "Switching between user devices during a VoIP call",
+            "number": "GB2479180A",
+            "url": "https://patents.google.com/patent/GB2479180A",
+            "summary": "Seamlessly transfer active calls between home electronics devices."
+        },
+        {
+            "name": "Location information in a communications system",
+            "number": "US9565261B2",
+            "url": "https://patents.google.com/patent/US9565261B2",
+            "summary": "Displaying location and timezone context within a contact list."
         }
     ],
     "certificates": [

--- a/src/_data/resume.json
+++ b/src/_data/resume.json
@@ -640,60 +640,70 @@
         {
             "name": "Distributing presence information",
             "number": "US8473545B2",
+            "date": "2013-06-25",
             "url": "https://patents.google.com/patent/US8473545B2/en",
             "summary": "Setting IM availability based on calendar data."
         },
         {
             "name": "Communication system and method",
             "number": "US8407749B2",
+            "date": "2013-03-26",
             "url": "https://patents.google.com/patent/US8407749B2/en",
             "summary": "Handling incoming call notifications via a TV remote control."
         },
         {
             "name": "Communication system and method",
             "number": "US8473994B2",
+            "date": "2013-06-25",
             "url": "https://patents.google.com/patent/US8473994B2/en",
             "summary": "Generating social avatars from live TV content."
         },
         {
             "name": "Communication system and method",
             "number": "EP2335411B1",
+            "date": "2017-03-01",
             "url": "https://patents.google.com/patent/EP2335411B1/en",
             "summary": "Bidirectional video calling over packet-based networks."
         },
         {
             "name": "Displaying graphical representations of contacts",
             "number": "US9128592B2",
+            "date": "2015-09-08",
             "url": "https://patents.google.com/patent/US9128592B2/en",
             "summary": "Dynamic resizing of contact avatars within a display region."
         },
         {
             "name": "Indicia of contact viewing activity",
             "number": "US9258511B2",
+            "date": "2016-02-09",
             "url": "https://patents.google.com/patent/US9258511B2/en",
             "summary": "Shared TV viewing indicators — watch shows together across platforms."
         },
         {
             "name": "Logging communication events using location information",
             "number": "US9544377B2",
+            "date": "2017-01-10",
             "url": "https://patents.google.com/patent/US9544377B2/en",
             "summary": "Location-aware phone call log."
         },
         {
             "name": "Switching between user devices during a VoIP call",
             "number": "GB2479180A",
+            "date": "2011-10-05",
             "url": "https://patents.google.com/patent/GB2479180A/en",
             "summary": "Seamlessly transfer active calls between home electronics devices."
         },
         {
             "name": "Location information in a communications system",
             "number": "US9565261B2",
+            "date": "2017-02-07",
             "url": "https://patents.google.com/patent/US9565261B2/en",
             "summary": "Displaying location and timezone context within a contact list."
         },
         {
             "name": "Location information in a communications system",
             "number": "US10524091B2",
+            "date": "2019-12-31",
             "url": "https://patents.google.com/patent/US10524091B2/en",
             "summary": "Displaying location and timezone context within a contact list."
         }

--- a/src/_data/resume.json
+++ b/src/_data/resume.json
@@ -14,7 +14,7 @@
             "city": "Kirkland",
             "postalCode": "98034"
         },
-        "summary": "Design leader with over 30 years background creating end-to-end experiences for web, cloud, terminal, mobile, desktop and consumer electronics platforms.",
+        "summary": "Design leader with over 30 years of experience creating end-to-end experiences for web, cloud, terminal, mobile, desktop and consumer electronics platforms.",
         "profiles": [
             {
                 "network": "X",
@@ -663,14 +663,14 @@
         },
         {
             "name": "Logging communication events",
-            "number": "US20110201313A1",
-            "url": "https://patents.google.com/patent/US20110201313A1",
+            "number": "US9544377B2",
+            "url": "https://patents.google.com/patent/US9544377B2",
             "summary": "Location-aware phone call log."
         },
         {
             "name": "Switching between user devices during a VoIP call",
-            "number": "GB2479180A",
-            "url": "https://patents.google.com/patent/GB2479180A",
+            "number": "GB2479180B",
+            "url": "https://patents.google.com/patent/GB2479180B",
             "summary": "Seamlessly transfer active calls between home electronics devices."
         },
         {

--- a/src/_data/resume.json
+++ b/src/_data/resume.json
@@ -522,6 +522,7 @@
         {
             "name": "Intel MID",
             "description": "Collaboration with Intel to develop VoIP calling for its Mobile Internet Device concept.",
+            "url": "https://www.theregister.com/2008/01/08/ces_skype_on_mid/",
             "entity": "Skype"
         },
         {

--- a/src/_data/resume.json
+++ b/src/_data/resume.json
@@ -638,45 +638,57 @@
     ],
     "patents": [
         {
-            "name": "Distributing Presence Information",
+            "name": "Distributing presence information",
             "number": "US8473545B2",
-            "url": "https://patents.google.com/patent/US8473545B2",
+            "url": "https://patents.google.com/patent/US8473545B2/en",
             "summary": "Setting IM availability based on calendar data."
         },
         {
             "name": "Communication system and method",
             "number": "US8407749B2",
-            "url": "https://patents.google.com/patent/US8407749B2",
+            "url": "https://patents.google.com/patent/US8407749B2/en",
             "summary": "Handling incoming call notifications via a TV remote control."
         },
         {
             "name": "Communication system and method",
             "number": "US8473994B2",
-            "url": "https://patents.google.com/patent/US8473994B2",
+            "url": "https://patents.google.com/patent/US8473994B2/en",
             "summary": "Generating social avatars from live TV content."
+        },
+        {
+            "name": "Communication system and method",
+            "number": "EP2335411B1",
+            "url": "https://patents.google.com/patent/EP2335411B1/en",
+            "summary": "Bidirectional video calling over packet-based networks."
+        },
+        {
+            "name": "Displaying graphical representations of contacts",
+            "number": "US9128592B2",
+            "url": "https://patents.google.com/patent/US9128592B2/en",
+            "summary": "Dynamic resizing of contact avatars within a display region."
         },
         {
             "name": "Indicia of contact viewing activity",
             "number": "US9258511B2",
-            "url": "https://patents.google.com/patent/US9258511B2",
+            "url": "https://patents.google.com/patent/US9258511B2/en",
             "summary": "Shared TV viewing indicators — watch shows together across platforms."
         },
         {
-            "name": "Logging communication events",
-            "number": "US9544377B2",
-            "url": "https://patents.google.com/patent/US9544377B2",
-            "summary": "Location-aware phone call log."
-        },
-        {
             "name": "Switching between user devices during a VoIP call",
-            "number": "GB2479180B",
-            "url": "https://patents.google.com/patent/GB2479180B",
+            "number": "GB2479180A",
+            "url": "https://patents.google.com/patent/GB2479180A/en",
             "summary": "Seamlessly transfer active calls between home electronics devices."
         },
         {
             "name": "Location information in a communications system",
             "number": "US9565261B2",
-            "url": "https://patents.google.com/patent/US9565261B2",
+            "url": "https://patents.google.com/patent/US9565261B2/en",
+            "summary": "Displaying location and timezone context within a contact list."
+        },
+        {
+            "name": "Location information in a communications system",
+            "number": "US10524091B2",
+            "url": "https://patents.google.com/patent/US10524091B2/en",
             "summary": "Displaying location and timezone context within a contact list."
         }
     ],

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -250,6 +250,27 @@ const projectGroups = groupBy(resume.projects, "entity");
     </ul>
   </section>
 
+  <section id="patents">
+    <h2 title="Patents">💡<span class="sr-only">Patents</span></h2>
+    <ul>
+      {
+        resume.patents.map((p) => (
+          <li id={slug(p.number)}>
+            <a
+              href={p.url}
+              rel="external noopener noreferrer"
+              target="_blank"
+              title={p.summary}
+            >
+              {p.number}
+            </a>
+            <span>{p.name}</span>
+          </li>
+        ))
+      }
+    </ul>
+  </section>
+
   <section id="projects">
     <h2 title="Projects">📁<span class="sr-only">Projects</span></h2>
     <dl>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -266,11 +266,10 @@ const projectGroups = groupBy(resume.projects, "entity");
                   href={p.url}
                   rel="external noopener noreferrer"
                   target="_blank"
-                  title={p.summary}
+                  title={p.number}
                 >
-                  {p.number}
-                </a>{" "}
-                {p.name}
+                  {p.name}
+                </a>
               </span>
             </li>
           ))

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -254,19 +254,26 @@ const projectGroups = groupBy(resume.projects, "entity");
     <h2 title="Patents">💡<span class="sr-only">Patents</span></h2>
     <ul>
       {
-        resume.patents.map((p) => (
-          <li id={slug(p.number)}>
-            <a
-              href={p.url}
-              rel="external noopener noreferrer"
-              target="_blank"
-              title={p.summary}
-            >
-              {p.number}
-            </a>
-            <span>{p.name}</span>
-          </li>
-        ))
+        [...resume.patents]
+          .sort((a, b) => b.date.localeCompare(a.date))
+          .map((p) => (
+            <li id={slug(p.number)}>
+              <time datetime={formatDate(p.date, "YYYY-MM-DD")}>
+                {formatDate(p.date, "YYYY")}
+              </time>
+              <span>
+                <a
+                  href={p.url}
+                  rel="external noopener noreferrer"
+                  target="_blank"
+                  title={p.summary}
+                >
+                  {p.number}
+                </a>{" "}
+                {p.name}
+              </span>
+            </li>
+          ))
       }
     </ul>
   </section>

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -170,6 +170,20 @@ figure {
   }
 }
 
+#patents {
+  li span a {
+    display: block;
+    &:hover {
+      padding: 0.25rem 0;
+      margin: -0.25rem 0;
+    }
+    &:focus-visible {
+      padding: 0.25rem 0;
+      margin: -0.25rem 0;
+    }
+  }
+}
+
 /* Indent company names */
 #work {
   dt {

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -206,6 +206,8 @@ dd {
       padding: 0.125rem 0.33rem;
       margin: -0.125rem -0.33rem;
       outline: none;
+      -webkit-box-decoration-break: clone;
+      box-decoration-break: clone;
     }
     &:focus-visible {
       text-decoration: none;
@@ -215,6 +217,8 @@ dd {
       margin: -0.125rem -0.33rem;
       outline: 2px solid var(--color-link);
       outline-offset: 2px;
+      -webkit-box-decoration-break: clone;
+      box-decoration-break: clone;
     }
   }
   span {

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -170,19 +170,6 @@ figure {
   }
 }
 
-#patents {
-  li span a {
-    display: block;
-    &:hover {
-      padding: 0.25rem 0;
-      margin: -0.25rem 0;
-    }
-    &:focus-visible {
-      padding: 0.25rem 0;
-      margin: -0.25rem 0;
-    }
-  }
-}
 
 /* Indent company names */
 #work {
@@ -220,6 +207,8 @@ dd {
       padding: 0.125rem 0.33rem;
       margin: -0.125rem -0.33rem;
       outline: none;
+      -webkit-box-decoration-break: clone;
+      box-decoration-break: clone;
     }
     &:focus-visible {
       text-decoration: none;
@@ -229,6 +218,8 @@ dd {
       margin: -0.125rem -0.33rem;
       outline: 2px solid var(--color-link);
       outline-offset: 2px;
+      -webkit-box-decoration-break: clone;
+      box-decoration-break: clone;
     }
   }
   span {

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Noto+Emoji:wght@300..700&display=swap&text=📁💼🏢🏆🫶🛠️📄📚👍");
+@import url("https://fonts.googleapis.com/css2?family=Noto+Emoji:wght@300..700&display=swap&text=📁💼🏢🏆🫶🛠️📄📚👍💡");
 
 :root {
   @supports (color: color(display-p3 1 1 1)) {

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -220,8 +220,6 @@ dd {
       padding: 0.125rem 0.33rem;
       margin: -0.125rem -0.33rem;
       outline: none;
-      -webkit-box-decoration-break: clone;
-      box-decoration-break: clone;
     }
     &:focus-visible {
       text-decoration: none;
@@ -231,8 +229,6 @@ dd {
       margin: -0.125rem -0.33rem;
       outline: 2px solid var(--color-link);
       outline-offset: 2px;
-      -webkit-box-decoration-break: clone;
-      box-decoration-break: clone;
     }
   }
   span {


### PR DESCRIPTION
## Summary

- **Patents section** — adds 7 granted US/UK patents as a non-standard top-level array (presence distribution, TV remote notifications, social avatars, shared viewing, location-aware call log, cross-device call transfer, location in contact lists)
- **New projects** — Windows 10 (Skype integration), Office 365 (Skype web comms), Intel MID (VoIP), Monty Python (ARTISTdirect webmaster)
- **Summary copy** — "almost 30 years" → "over 30 years"

## Test plan

- [ ] `pnpm build` passes
- [ ] Patents section renders correctly (requires template support — may need a follow-up to expose it in the UI)
- [ ] New projects appear under correct entity groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)