### PR TITLE
Re-enable default font smoothing

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -61,6 +61,8 @@ body {
     transparent 1px
   );
   background-size: 16px 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 
   @media (min-width: 992px) {
     padding: 2rem 3rem;

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -61,8 +61,6 @@ body {
     transparent 1px
   );
   background-size: 16px 16px;
-  -webkit-font-smoothing: none;
-  -moz-osx-font-smoothing: grayscale;
 
   @media (min-width: 992px) {
     padding: 2rem 3rem;


### PR DESCRIPTION
## Summary
- Drop `-webkit-font-smoothing: none` and `-moz-osx-font-smoothing: grayscale` from `body` in `src/styles/style.scss` so text renders with each browser's default smoothing again.
- The pixel-art SVG icons (`@iconify-json/pixel`) are untouched — these CSS properties only affect text rasterization, not SVG/vector rendering, so icons stay crisp.

## Test plan
- [x] `pnpm build` succeeds
- [ ] Spot-check `pnpm preview` on macOS and Windows to confirm body text looks smoothed and the `h2` pixel icons still render cleanly

https://claude.ai/code/session_01SGUe4R7yNyBkUEyAS8exmw