### PR TITLE
Add DESIGN.md design system documentation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,207 @@
+# DESIGN.md — mark.mclaughlin.me.uk
+
+A single-page static résumé site. The aesthetic is deliberately terminal-coded: monospace system fonts, a coral accent that reads like a prompt, electric-blue links that invert on hover, and a global `lowercase` transform that makes even proper nouns feel like shell output. Minimalist and content-first, with no decorative chrome beyond a subtle dot-grid background.
+
+---
+
+## 1. Visual Theme & Atmosphere
+
+**Mood:** Technical, calm, high-contrast. Feels like a well-configured terminal or a code editor with a light theme. Every typographic choice reinforces the developer/designer persona without being gimmicky.
+
+**Key signals:**
+- Monospace everywhere — font choice is the single loudest design statement.
+- Global `text-transform: lowercase` on the body; headings and structural labels (`dt`, footer) are `uppercase`. The contrast between the two creates visual rhythm without extra weight.
+- Pixel-art icons for section headings (32 × 32 px, `@iconify-json/pixel`) — lo-fi and charming, never distracting.
+- Blinking block cursor after the summary paragraph, 1.333 s animation — the one piece of motion on the page.
+- Flat. No shadows, no cards, no gradients beyond the background texture.
+
+---
+
+## 2. Color Palette & Roles
+
+All colors are declared as CSS custom properties with a Display P3 wide-gamut primary and sRGB fallback.
+
+| Token | Display P3 | sRGB Fallback | Role |
+|---|---|---|---|
+| `--color-primary` | `color(display-p3 1 0.32 0.285)` | `#ff5249` | Headings, section icons, borders, blinking cursor, link hover backgrounds |
+| `--color-link` | `color(display-p3 0 0.25 1 / 1)` | `#0040ff` | Body links (resting), link hover/focus backgrounds |
+| `--color-background` | `color(display-p3 0.98 0.98 0.98)` | `#f8f9fa` | Page background |
+| `--opacity-muted` | — | `0.6` | Dates and separator glyphs (applied via `opacity`) |
+| `--border-radius` | — | `2px` | All rounded corners |
+
+**White** (`#ffffff`) appears only as the foreground color on hover/focus interactive states — it is not a named token but is hardcoded in those rules.
+
+Body text is unset (inherits browser default near-black on the near-white background). There are no explicit neutral tokens because the monochrome body text is intentional.
+
+---
+
+## 3. Typography Rules
+
+**Font family (single stack, applied to `body`):**
+```
+ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+"Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
+"Fira Mono", "Droid Sans Mono", "Courier New", monospace
+```
+
+No web fonts are loaded. The stack resolves to the best available system monospace font.
+
+| Element | Size | Weight | Transform | Color | Notes |
+|---|---|---|---|---|---|
+| `h1` | `1.5rem` | 500 | `uppercase` | `--color-primary` | Name / page title |
+| `h2` | inherits | — | — | `--color-primary` | Replaced visually by a 32 px pixel-art icon; text is `.sr-only` |
+| `h3` | `0.85rem` | 500 | `lowercase` (inherits) | inherits | Role/position labels |
+| `dt` | inherits | 600 | `uppercase` | inherits | Company / entity group headings |
+| Body (≥768 px) | `0.85rem` | 400 | `lowercase` | inherits | — |
+| Body (<768 px) | `1rem` | 400 | `lowercase` | inherits | Larger tap-friendly size |
+| `footer` | inherits | 400 | `uppercase` | inherits | Copyright and social links |
+| `figcaption` | inherits | 600 | `uppercase` | inherits | Quote attribution |
+
+**Line height:** `1.333rem` (applied to `body`; used as the animation timing unit too).
+
+**Anti-aliasing:** `-webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale`
+
+---
+
+## 4. Component Stylings
+
+### Links
+- **Resting:** `color: --color-link`, `text-decoration: none`
+- **Hover:** background `--color-link`, text `#fff`, padding `0.125rem 0.33rem`, margin `-0.125rem -0.33rem` (optical compensation), `border-radius: 2px`, `box-decoration-break: clone` (for multi-line wraps)
+- **Focus-visible:** same as hover plus `outline: 2px solid --color-link; outline-offset: 2px`
+
+### Section headings (`h2`)
+Icon-only: a 32 × 32 px pixel SVG from the `pixel:` Iconify set. Text content is present in the DOM as `.sr-only` for accessibility. Color inherits `currentColor` from `--color-primary`.
+
+Available section icons: `pixel:briefcase` (work), `pixel:trophy` (awards), `pixel:heart` (volunteer), `pixel:badge-check` (certificates), `pixel:book` (publications), `pixel:lightbulb` (patents), `pixel:folder` (projects).
+
+### Definition lists (`<dl>`, `<dt>`, `<dd>`)
+- `dt`: `text-transform: uppercase; font-weight: 600; margin-top: 1.5rem`
+- `dd`: `display: flex; flex-direction: row; gap: 1rem; margin: 0`
+- Work section `dt` is additionally indented by `3.1rem` to align with the year column in `dd`.
+- At ≥768 px, the Projects `dl` switches to a 2-column grid (`grid-template-columns: 1fr 1fr; column-gap: 2rem`) with `dt` spanning both columns.
+
+### Lists (`<ul>`, `<li>`)
+- `list-style-type: none; padding-left: 0; margin-left: 0`
+- `li`: `display: flex; flex-direction: row; gap: 1rem`
+
+### Sections
+- `margin-top: 4rem` for vertical rhythm between every section.
+
+### Date / muted text
+- `opacity: 0.6` via `.muted` class or `time` element selector inside `section`.
+
+### Figure / blockquote
+- `margin: 2rem 0`
+- `blockquote`: `border-left: 1px solid --color-primary; margin-left: 0.25rem; padding-left: 0.75rem`
+- `figcaption`: `font-weight: 600; text-transform: uppercase`
+
+### Footer
+- `border-top: 1px solid --color-primary; padding-top: 1rem; text-transform: uppercase`
+- Social icon links are 20 × 20 px inline SVGs, vertically middle-aligned.
+- Footer `a` hover/focus: `height: 24px; padding: 4px; margin: -4px; border-radius: 2px`
+
+### Blinking cursor (summary paragraph)
+- `p#summary::after`: inline 0.5em × 1em block, `background-color: --color-primary`, `animation: cursor-blink 1.333s steps(2) infinite`
+
+---
+
+## 5. Layout Principles
+
+**Column model:** The page is a single centred column. Max-width narrows progressively as the viewport widens, keeping line lengths comfortable.
+
+| Breakpoint | Max-width | Padding |
+|---|---|---|
+| ≥ 992 px | `44vw` | `2rem 3rem` |
+| 768–991 px | `60vw` | `2rem 2rem` |
+| 576–767 px | `80vw` | `2rem 1rem` |
+| < 576 px | `100vw` | `2rem 1rem` |
+
+**Spacing scale (used in context, not a separate token system):**
+
+| Usage | Value |
+|---|---|
+| Section gap | `4rem` |
+| `dt` top margin | `1.5rem` |
+| `h3` top margin | `0.5rem` |
+| Figure margin | `2rem 0` |
+| Gap inside `li` / `dd` | `1rem` |
+| Footer top padding | `1rem` |
+| Inline social icon gap | `0.5rem` |
+| Link hover padding | `0.125rem 0.33rem` |
+
+**Background texture:** `radial-gradient(circle, color-mix(in srgb, currentColor 12%, transparent) 1px, transparent 1px)` tiled at `16px 16px`. Creates an unobtrusive dot grid that reinforces the grid/terminal aesthetic.
+
+---
+
+## 6. Depth & Elevation
+
+There are **no shadows**. The design is entirely flat. Surface hierarchy is established exclusively through:
+- Typography weight and case (`uppercase` labels vs `lowercase` body)
+- Opacity (muted dates at 0.6)
+- Color (primary accent for headings and structural borders)
+- Whitespace (4 rem section gaps)
+
+Do not add `box-shadow` or `drop-shadow` to any element.
+
+---
+
+## 7. Do's and Don'ts
+
+### Do
+- Use the monospace system font stack for all text, including any new components.
+- Apply `text-transform: lowercase` to all new body-level content; `uppercase` only for structural labels (`dt`, `footer`, headings).
+- Keep interactive highlight states consistent: white text on `--color-link` background with `border-radius: 2px` and `box-decoration-break: clone`.
+- Add `rel="external noopener noreferrer" target="_blank"` to all outbound links except footer profile links (which use `rel="me"`).
+- Prefix `<dt>` ids in new `<dl>` sections to avoid clashes: e.g. `work--{slug}`, `projects--{slug}`.
+- Use `opacity: 0.6` (`.muted`) for secondary information like dates and separators rather than a separate grey colour.
+- Use `pixel:` icons exclusively for section headings; pick from the declared subset in `astro.config.mjs`.
+
+### Don't
+- Don't load web fonts. The entire typographic system runs on system monospace.
+- Don't use border-radius values other than `2px` (`--border-radius`).
+- Don't add shadows, cards, or elevated surfaces.
+- Don't use `text-transform: capitalize` on visible text (it's reserved for `.sr-only` to fix screen-reader pronunciation).
+- Don't introduce new accent colours. The palette is intentionally minimal: one warm accent, one cool link colour, one near-white background.
+- Don't add `text-decoration: underline` to links; hover highlight is the only affordance.
+- Don't inject analytics scripts or third-party resources outside the `isProd` guard in `Layout.astro`.
+
+---
+
+## 8. Responsive Behavior
+
+**Breakpoints:**
+
+| Name | Range | Notes |
+|---|---|---|
+| Mobile | < 576 px | Full width, 1rem font, `dd > span` forced block |
+| Tablet-sm | 576–767 px | 80vw, footer switches to `flex-direction: row` |
+| Tablet-lg | 768–991 px | 60vw, projects grid activates |
+| Desktop | ≥ 992 px | 44vw, smallest font size (0.85rem) |
+
+**Projects grid:** At ≥ 768 px the projects `<dl>` renders as `grid-template-columns: 1fr 1fr` with `<dt>` spanning both columns (`grid-column: 1 / -1`).
+
+**Footer:** Single column (stacked) on mobile; `display: flex; justify-content: space-between` at ≥ 575 px.
+
+**Work `dt` indent:** `calc(3.1rem - 2px)` at ≥ 768 px; `calc(3.5rem - 2px)` on mobile to maintain year-column alignment.
+
+**Touch targets:** Social icon links in the footer expand to `24 × 24 px` on hover/focus via negative margin compensation. Minimum 44 px touch targets should be maintained for any new interactive elements added on mobile.
+
+---
+
+## 9. Agent Prompt Guide
+
+**Colour references (use these names in prompts):**
+- `primary` = coral/red accent `#ff5249`
+- `link` = electric blue `#0040ff`
+- `background` = off-white `#f8f9fa`
+
+**Quick prompts:**
+
+> "Add a new résumé section matching the existing work section style: `<dl>` with `uppercase dt` headings prefixed `{section}--{slug}`, and `flex-row dd` items with a muted date column on the left."
+
+> "Add a new icon-only `h2` using a `pixel:` icon. Include `.sr-only` text for the label. Colour inherits `--color-primary` via `currentColor`."
+
+> "Style a new link consistent with the site: no underline at rest; on hover, white text on `--color-link` background with `padding: 0.125rem 0.33rem`, `margin: -0.125rem -0.33rem`, `border-radius: 2px`, and `box-decoration-break: clone`."
+
+> "Adjust this component for the mobile breakpoint (<576 px): increase font to 1rem, set `line-height: 1.6rem` on list items."

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -89,7 +89,7 @@ Available section icons: `pixel:briefcase` (work), `pixel:trophy` (awards), `pix
 - `margin-top: 4rem` for vertical rhythm between every section.
 
 ### Date / muted text
-- `opacity: 0.6` via `.muted` class or `time` element selector inside `section`.
+- `opacity: var(--opacity-muted)` via `.muted` class or `time` element selector inside `section`.
 
 ### Figure / blockquote
 - `margin: 2rem 0`
@@ -138,7 +138,7 @@ Available section icons: `pixel:briefcase` (work), `pixel:trophy` (awards), `pix
 
 There are **no shadows**. The design is entirely flat. Surface hierarchy is established exclusively through:
 - Typography weight and case (`uppercase` labels vs `lowercase` body)
-- Opacity (muted dates at 0.6)
+- Opacity (muted dates at `var(--opacity-muted)`)
 - Color (primary accent for headings and structural borders)
 - Whitespace (4 rem section gaps)
 
@@ -154,7 +154,7 @@ Do not add `box-shadow` or `drop-shadow` to any element.
 - Keep interactive highlight states consistent: white text on `--color-link` background with `border-radius: 2px` and `box-decoration-break: clone`.
 - Add `rel="external noopener noreferrer" target="_blank"` to all outbound links except footer profile links (which use `rel="me"`).
 - Prefix `<dt>` ids in new `<dl>` sections to avoid clashes: e.g. `work--{slug}`, `projects--{slug}`.
-- Use `opacity: 0.6` (`.muted`) for secondary information like dates and separators rather than a separate grey colour.
+- Use `var(--opacity-muted)` (`.muted`) for secondary information like dates and separators rather than a separate gray color.
 - Use `pixel:` icons exclusively for section headings; pick from the declared subset in `astro.config.mjs`.
 
 ### Don't
@@ -162,9 +162,9 @@ Do not add `box-shadow` or `drop-shadow` to any element.
 - Don't use border-radius values other than `2px` (`--border-radius`).
 - Don't add shadows, cards, or elevated surfaces.
 - Don't use `text-transform: capitalize` on visible text (it's reserved for `.sr-only` to fix screen-reader pronunciation).
-- Don't introduce new accent colours. The palette is intentionally minimal: one warm accent, one cool link colour, one near-white background.
+- Don't introduce new accent colors. The palette is intentionally minimal: one warm accent, one cool link color, one near-white background.
 - Don't add `text-decoration: underline` to links; hover highlight is the only affordance.
-- Don't inject analytics scripts or third-party resources outside the `isProd` guard in `Layout.astro`.
+- Don't inject analytics scripts or third-party resources outside the `isProd` guard in `Layout.astro`, except the Cloudflare Web Analytics beacon which is intentionally always loaded (including in dev).
 
 ---
 
@@ -181,9 +181,9 @@ Do not add `box-shadow` or `drop-shadow` to any element.
 
 **Projects grid:** At ≥ 768 px the projects `<dl>` renders as `grid-template-columns: 1fr 1fr` with `<dt>` spanning both columns (`grid-column: 1 / -1`).
 
-**Footer:** Single column (stacked) on mobile; `display: flex; justify-content: space-between` at ≥ 575 px.
+**Footer:** Single column (stacked) on mobile; `display: flex; justify-content: space-between` at ≥ 576 px.
 
-**Work `dt` indent:** `calc(3.1rem - 2px)` at ≥ 768 px; `calc(3.5rem - 2px)` on mobile to maintain year-column alignment.
+**Work `dt` indent:** `calc(3.1rem - 2px)` at ≥ 768 px; `calc(3.5rem - 2px)` at < 768 px to maintain year-column alignment.
 
 **Touch targets:** Social icon links in the footer expand to `24 × 24 px` on hover/focus via negative margin compensation. Minimum 44 px touch targets should be maintained for any new interactive elements added on mobile.
 
@@ -191,7 +191,7 @@ Do not add `box-shadow` or `drop-shadow` to any element.
 
 ## 9. Agent Prompt Guide
 
-**Colour references (use these names in prompts):**
+**Color references (use these names in prompts):**
 - `primary` = coral/red accent `#ff5249`
 - `link` = electric blue `#0040ff`
 - `background` = off-white `#f8f9fa`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -23,7 +23,7 @@ All colors are declared as CSS custom properties with a Display P3 wide-gamut pr
 
 | Token | Display P3 | sRGB Fallback | Role |
 |---|---|---|---|
-| `--color-primary` | `color(display-p3 1 0.32 0.285)` | `#ff5249` | Headings, section icons, borders, blinking cursor, link hover backgrounds |
+| `--color-primary` | `color(display-p3 1 0.32 0.285)` | `#ff5249` | Headings, section icons, borders, blinking cursor |
 | `--color-link` | `color(display-p3 0 0.25 1 / 1)` | `#0040ff` | Body links (resting), link hover/focus backgrounds |
 | `--color-background` | `color(display-p3 0.98 0.98 0.98)` | `#f8f9fa` | Page background |
 | `--opacity-muted` | — | `0.6` | Dates and separator glyphs (applied via `opacity`) |
@@ -68,7 +68,7 @@ No web fonts are loaded. The stack resolves to the best available system monospa
 ### Links
 - **Resting:** `color: --color-link`, `text-decoration: none`
 - **Hover:** background `--color-link`, text `#fff`, padding `0.125rem 0.33rem`, margin `-0.125rem -0.33rem` (optical compensation), `border-radius: 2px`, `box-decoration-break: clone` (for multi-line wraps)
-- **Focus-visible:** same as hover plus `outline: 2px solid --color-link; outline-offset: 2px`
+- **Focus-visible:** background `--color-link`, text `#fff`, padding `0.125rem 0.33rem`, margin `-0.125rem -0.33rem`, `box-decoration-break: clone`, `outline: 2px solid --color-link; outline-offset: 2px` (no `border-radius` — differs from hover)
 
 ### Section headings (`h2`)
 Icon-only: a 32 × 32 px pixel SVG from the `pixel:` Iconify set. Text content is present in the DOM as `.sr-only` for accessibility. Color inherits `currentColor` from `--color-primary`.
@@ -77,13 +77,15 @@ Available section icons: `pixel:briefcase` (work), `pixel:trophy` (awards), `pix
 
 ### Definition lists (`<dl>`, `<dt>`, `<dd>`)
 - `dt`: `text-transform: uppercase; font-weight: 600; margin-top: 1.5rem`
-- `dd`: `display: flex; flex-direction: row; gap: 1rem; margin: 0`
+- `dd`: default `display: flex; flex-direction: row; gap: 1rem; margin: 0`
 - Work section `dt` is additionally indented by `3.1rem` to align with the year column in `dd`.
-- At ≥768 px, the Projects `dl` switches to a 2-column grid (`grid-template-columns: 1fr 1fr; column-gap: 2rem`) with `dt` spanning both columns.
+- At ≥768 px, the Projects `dl` switches to a 2-column grid (`grid-template-columns: 1fr 1fr; column-gap: 2rem`) with `dt` spanning both columns; in that layout, Projects `dd` overrides the default and uses `display: block`.
 
-### Lists (`<ul>`, `<li>`)
+### Content lists (`<ul>`, `<li>`)
+Applies to work, awards, volunteer, certificates, publications, patents, and projects sections.
 - `list-style-type: none; padding-left: 0; margin-left: 0`
 - `li`: `display: flex; flex-direction: row; gap: 1rem`
+- Footer `li` is styled differently: `display: inline` with `margin-left: 0.5rem`.
 
 ### Sections
 - `margin-top: 4rem` for vertical rhythm between every section.
@@ -174,7 +176,7 @@ Do not add `box-shadow` or `drop-shadow` to any element.
 
 | Name | Range | Notes |
 |---|---|---|
-| Mobile | < 576 px | Full width, 1rem font, `dd > span` forced block |
+| Mobile | < 576 px | Full width, 1rem font, `dd > span` set to `inline-block` |
 | Tablet-sm | 576–767 px | 80vw, footer switches to `flex-direction: row` |
 | Tablet-lg | 768–991 px | 60vw, projects grid activates |
 | Desktop | ≥ 992 px | 44vw, smallest font size (0.85rem) |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,209 +1,40 @@
 # DESIGN.md — mark.mclaughlin.me.uk
 
-A single-page static résumé site. The aesthetic is deliberately terminal-coded: monospace system fonts, a coral accent that reads like a prompt, electric-blue links that invert on hover, and a global `lowercase` transform that makes even proper nouns feel like shell output. Minimalist and content-first, with no decorative chrome beyond a subtle dot-grid background.
+Terminal-coded résumé. Monospace system fonts, coral accent, electric-blue links that invert on hover, global `lowercase` body text. Flat, minimal, content-first.
 
----
+## Colors
 
-## 1. Visual Theme & Atmosphere
-
-**Mood:** Technical, calm, high-contrast. Feels like a well-configured terminal or a code editor with a light theme. Every typographic choice reinforces the developer/designer persona without being gimmicky.
-
-**Key signals:**
-- Monospace everywhere — font choice is the single loudest design statement.
-- Global `text-transform: lowercase` on the body; headings and structural labels (`dt`, footer) are `uppercase`. The contrast between the two creates visual rhythm without extra weight.
-- Pixel-art icons for section headings (32 × 32 px, `@iconify-json/pixel`) — lo-fi and charming, never distracting.
-- Blinking block cursor after the summary paragraph, 1.333 s animation — the one piece of motion on the page.
-- Flat. No shadows, no cards, no gradients beyond the background texture.
-
----
-
-## 2. Color Palette & Roles
-
-All colors are declared as CSS custom properties with a Display P3 wide-gamut primary and sRGB fallback.
-
-| Token | Display P3 | sRGB Fallback | Role |
-|---|---|---|---|
-| `--color-primary` | `color(display-p3 1 0.32 0.285)` | `#ff5249` | Headings, section icons, borders, blinking cursor |
-| `--color-link` | `color(display-p3 0 0.25 1 / 1)` | `#0040ff` | Body links (resting), link hover/focus backgrounds |
-| `--color-background` | `color(display-p3 0.98 0.98 0.98)` | `#f8f9fa` | Page background |
-| `--opacity-muted` | — | `0.6` | Dates and separator glyphs (applied via `opacity`) |
-| `--border-radius` | — | `2px` | All rounded corners |
-
-**White** (`#ffffff`) appears only as the foreground color on hover/focus interactive states — it is not a named token but is hardcoded in those rules.
-
-Body text is unset (inherits browser default near-black on the near-white background). There are no explicit neutral tokens because the monochrome body text is intentional.
-
----
-
-## 3. Typography Rules
-
-**Font family (single stack, applied to `body`):**
-```
-ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
-"Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
-"Fira Mono", "Droid Sans Mono", "Courier New", monospace
-```
-
-No web fonts are loaded. The stack resolves to the best available system monospace font.
-
-| Element | Size | Weight | Transform | Color | Notes |
-|---|---|---|---|---|---|
-| `h1` | `1.5rem` | 500 | `uppercase` | `--color-primary` | Name / page title |
-| `h2` | inherits | — | — | `--color-primary` | Replaced visually by a 32 px pixel-art icon; text is `.sr-only` |
-| `h3` | `0.85rem` | 500 | `lowercase` (inherits) | inherits | Role/position labels |
-| `dt` | inherits | 600 | `uppercase` | inherits | Company / entity group headings |
-| Body (≥768 px) | `0.85rem` | 400 | `lowercase` | inherits | — |
-| Body (<768 px) | `1rem` | 400 | `lowercase` | inherits | Larger tap-friendly size |
-| `footer` | inherits | 400 | `uppercase` | inherits | Copyright and social links |
-| `figcaption` | inherits | 600 | `uppercase` | inherits | Quote attribution |
-
-**Line height:** `1.333rem` (applied to `body`; used as the animation timing unit too).
-
-**Anti-aliasing:** `-webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale`
-
----
-
-## 4. Component Stylings
-
-### Links
-- **Resting:** `color: --color-link`, `text-decoration: none`
-- **Hover:** background `--color-link`, text `#fff`, padding `0.125rem 0.33rem`, margin `-0.125rem -0.33rem` (optical compensation), `border-radius: 2px`, `box-decoration-break: clone` (for multi-line wraps)
-- **Focus-visible:** background `--color-link`, text `#fff`, padding `0.125rem 0.33rem`, margin `-0.125rem -0.33rem`, `box-decoration-break: clone`, `outline: 2px solid --color-link; outline-offset: 2px` (no `border-radius` — differs from hover)
-
-### Section headings (`h2`)
-Icon-only: a 32 × 32 px pixel SVG from the `pixel:` Iconify set. Text content is present in the DOM as `.sr-only` for accessibility. Color inherits `currentColor` from `--color-primary`.
-
-Available section icons: `pixel:briefcase` (work), `pixel:trophy` (awards), `pixel:heart` (volunteer), `pixel:badge-check` (certificates), `pixel:book` (publications), `pixel:lightbulb` (patents), `pixel:folder` (projects).
-
-### Definition lists (`<dl>`, `<dt>`, `<dd>`)
-- `dt`: `text-transform: uppercase; font-weight: 600; margin-top: 1.5rem`
-- `dd`: default `display: flex; flex-direction: row; gap: 1rem; margin: 0`
-- Work section `dt` is additionally indented by `3.1rem` to align with the year column in `dd`.
-- At ≥768 px, the Projects `dl` switches to a 2-column grid (`grid-template-columns: 1fr 1fr; column-gap: 2rem`) with `dt` spanning both columns; in that layout, Projects `dd` overrides the default and uses `display: block`.
-
-### Content lists (`<ul>`, `<li>`)
-Applies to work, awards, volunteer, certificates, publications, patents, and projects sections.
-- `list-style-type: none; padding-left: 0; margin-left: 0`
-- `li`: `display: flex; flex-direction: row; gap: 1rem`
-- Footer `li` is styled differently: `display: inline` with `margin-left: 0.5rem`.
-
-### Sections
-- `margin-top: 4rem` for vertical rhythm between every section.
-
-### Date / muted text
-- `opacity: var(--opacity-muted)` via `.muted` class or `time` element selector inside `section`.
-
-### Figure / blockquote
-- `margin: 2rem 0`
-- `blockquote`: `border-left: 1px solid --color-primary; margin-left: 0.25rem; padding-left: 0.75rem`
-- `figcaption`: `font-weight: 600; text-transform: uppercase`
-
-### Footer
-- `border-top: 1px solid --color-primary; padding-top: 1rem; text-transform: uppercase`
-- Social icon links are 20 × 20 px inline SVGs, vertically middle-aligned.
-- Footer `a` hover/focus: `height: 24px; padding: 4px; margin: -4px; border-radius: 2px`
-
-### Blinking cursor (summary paragraph)
-- `p#summary::after`: inline 0.5em × 1em block, `background-color: --color-primary`, `animation: cursor-blink 1.333s steps(2) infinite`
-
----
-
-## 5. Layout Principles
-
-**Column model:** The page is a single centred column. Max-width narrows progressively as the viewport widens, keeping line lengths comfortable.
-
-| Breakpoint | Max-width | Padding |
+| Token | Value | Role |
 |---|---|---|
-| ≥ 992 px | `44vw` | `2rem 3rem` |
-| 768–991 px | `60vw` | `2rem 2rem` |
-| 576–767 px | `80vw` | `2rem 1rem` |
-| < 576 px | `100vw` | `2rem 1rem` |
+| `--color-primary` | `#ff5249` | Headings, icons, borders, cursor |
+| `--color-link` | `#0040ff` | Links; hover/focus background |
+| `--color-background` | `#f8f9fa` | Page background |
+| `--opacity-muted` | `0.6` | Dates and secondary text |
+| `--border-radius` | `2px` | All rounded corners |
 
-**Spacing scale (used in context, not a separate token system):**
+Wide-gamut displays get Display P3 values via `@supports`; the hex values above are the sRGB fallbacks.
 
-| Usage | Value |
-|---|---|
-| Section gap | `4rem` |
-| `dt` top margin | `1.5rem` |
-| `h3` top margin | `0.5rem` |
-| Figure margin | `2rem 0` |
-| Gap inside `li` / `dd` | `1rem` |
-| Footer top padding | `1rem` |
-| Inline social icon gap | `0.5rem` |
-| Link hover padding | `0.125rem 0.33rem` |
+## Typography
 
-**Background texture:** `radial-gradient(circle, color-mix(in srgb, currentColor 12%, transparent) 1px, transparent 1px)` tiled at `16px 16px`. Creates an unobtrusive dot grid that reinforces the grid/terminal aesthetic.
+System monospace stack (`ui-monospace, Menlo, Monaco, …`). No web fonts.
 
----
+- Body: `0.85rem` / `1rem` on mobile, `line-height: 1.333rem`, `text-transform: lowercase`
+- `h1`: `1.5rem`, weight 500, `uppercase`, `--color-primary`
+- `dt`: weight 600, `uppercase`
+- `h2`: icon-only (32 px pixel SVG); label is `.sr-only`
 
-## 6. Depth & Elevation
+## Interactions
 
-There are **no shadows**. The design is entirely flat. Surface hierarchy is established exclusively through:
-- Typography weight and case (`uppercase` labels vs `lowercase` body)
-- Opacity (muted dates at `var(--opacity-muted)`)
-- Color (primary accent for headings and structural borders)
-- Whitespace (4 rem section gaps)
+Links have no underline. On hover/focus: white text on `--color-link` background, `padding: 0.125rem 0.33rem`, negative margin to compensate, `border-radius: 2px`, `box-decoration-break: clone`.
 
-Do not add `box-shadow` or `drop-shadow` to any element.
+## Layout
 
----
+Single centered column. Max-width scales with viewport: `44vw` on desktop, `60vw` tablet, `80vw` small tablet, `100vw` mobile. Sections spaced `4rem` apart. No shadows or elevation — hierarchy through type weight, case, and whitespace.
 
-## 7. Do's and Don'ts
+## Rules
 
-### Do
-- Use the monospace system font stack for all text, including any new components.
-- Apply `text-transform: lowercase` to all new body-level content; `uppercase` only for structural labels (`dt`, `footer`, headings).
-- Keep interactive highlight states consistent: white text on `--color-link` background with `border-radius: 2px` and `box-decoration-break: clone`.
-- Add `rel="external noopener noreferrer" target="_blank"` to all outbound links except footer profile links (which use `rel="me"`).
-- Prefix `<dt>` ids in new `<dl>` sections to avoid clashes: e.g. `work--{slug}`, `projects--{slug}`.
-- Use `var(--opacity-muted)` (`.muted`) for secondary information like dates and separators rather than a separate gray color.
-- Use `pixel:` icons exclusively for section headings; pick from the declared subset in `astro.config.mjs`.
-
-### Don't
-- Don't load web fonts. The entire typographic system runs on system monospace.
-- Don't use border-radius values other than `2px` (`--border-radius`).
-- Don't add shadows, cards, or elevated surfaces.
-- Don't use `text-transform: capitalize` on visible text (it's reserved for `.sr-only` to fix screen-reader pronunciation).
-- Don't introduce new accent colors. The palette is intentionally minimal: one warm accent, one cool link color, one near-white background.
-- Don't add `text-decoration: underline` to links; hover highlight is the only affordance.
-- Don't inject analytics scripts or third-party resources outside the `isProd` guard in `Layout.astro`, except the Cloudflare Web Analytics beacon which is intentionally always loaded (including in dev).
-
----
-
-## 8. Responsive Behavior
-
-**Breakpoints:**
-
-| Name | Range | Notes |
-|---|---|---|
-| Mobile | < 576 px | Full width, 1rem font, `dd > span` set to `inline-block` |
-| Tablet-sm | 576–767 px | 80vw, footer switches to `flex-direction: row` |
-| Tablet-lg | 768–991 px | 60vw, projects grid activates |
-| Desktop | ≥ 992 px | 44vw, smallest font size (0.85rem) |
-
-**Projects grid:** At ≥ 768 px the projects `<dl>` renders as `grid-template-columns: 1fr 1fr` with `<dt>` spanning both columns (`grid-column: 1 / -1`).
-
-**Footer:** Single column (stacked) on mobile; `display: flex; justify-content: space-between` at ≥ 576 px.
-
-**Work `dt` indent:** `calc(3.1rem - 2px)` at ≥ 768 px; `calc(3.5rem - 2px)` at < 768 px to maintain year-column alignment.
-
-**Touch targets:** Social icon links in the footer expand to `24 × 24 px` on hover/focus via negative margin compensation. Minimum 44 px touch targets should be maintained for any new interactive elements added on mobile.
-
----
-
-## 9. Agent Prompt Guide
-
-**Color references (use these names in prompts):**
-- `primary` = coral/red accent `#ff5249`
-- `link` = electric blue `#0040ff`
-- `background` = off-white `#f8f9fa`
-
-**Quick prompts:**
-
-> "Add a new résumé section matching the existing work section style: `<dl>` with `uppercase dt` headings prefixed `{section}--{slug}`, and `flex-row dd` items with a muted date column on the left."
-
-> "Add a new icon-only `h2` using a `pixel:` icon. Include `.sr-only` text for the label. Colour inherits `--color-primary` via `currentColor`."
-
-> "Style a new link consistent with the site: no underline at rest; on hover, white text on `--color-link` background with `padding: 0.125rem 0.33rem`, `margin: -0.125rem -0.33rem`, `border-radius: 2px`, and `box-decoration-break: clone`."
-
-> "Adjust this component for the mobile breakpoint (<576 px): increase font to 1rem, set `line-height: 1.6rem` on list items."
+- No web fonts, no shadows, no cards
+- `border-radius` is always `2px`
+- New `<dl>` sections must prefix `<dt>` ids: `{section}--{slug}`
+- External links: `rel="external noopener noreferrer" target="_blank"`
+- New section headings use `pixel:` icons from the declared subset in `astro.config.mjs`


### PR DESCRIPTION
## Summary

Adds a `DESIGN.md` to the repo root in [Google Stitch DESIGN.md](https://stitch.withgoogle.com/docs/design-md/specification) format — a concise, plain-text design system document for AI agents and contributors.

Covers the essentials: color tokens (with Display P3 + sRGB fallbacks), typography stack, link interaction pattern, layout model, and key rules. Deliberately kept short so it's actually useful as a quick reference.

## Test plan

- [ ] Read `DESIGN.md` and verify color hex values match `src/styles/style.scss` custom properties
- [ ] Confirm rules (no web fonts, no shadows, `border-radius: 2px`, `dt` id prefixing) match the existing implementation

https://claude.ai/code/session_01FMyYy1pCsBpWqiF42q5JK8